### PR TITLE
Forward `null` when parent cannot be found

### DIFF
--- a/java/com/google/copybara/WorkflowMode.java
+++ b/java/com/google/copybara/WorkflowMode.java
@@ -263,12 +263,7 @@ public enum WorkflowMode {
           runHelper,
           baseline,
           runHelper.workflowOptions().baselineForMergeImport == null
-              ? baseline
-                  .orElseThrow(() ->
-                      new ValidationException(
-                          "Cannot read origin revision from baseline, please specify the baseline"
-                              + " using the --baseline-for-merge-import flag."))
-                  .getOriginRevision()
+              ? baseline.map((Baseline<O> b) -> b.getOriginRevision()).orElse(null)
               : runHelper.originResolveLastRev(runHelper.workflowOptions().baselineForMergeImport));
     }},
     @DocField(


### PR DESCRIPTION
Currently if I run a workflow where the parent commit cannot be found in
the destination (with merge_import from
[here](https://github.com/google/copybara/commit/c54a5b9158cedabade4f96fd688405ffa6a843a5)
off), I get an exception:
```
java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.get(Optional.java:148)
        at com.google.copybara.WorkflowMode$3.run(WorkflowMode.java:261)
        at com.google.copybara.Workflow.run(Workflow.java:288)
        at com.google.copybara.MigrateCmd.run(MigrateCmd.java:92)
        at com.google.copybara.MigrateCmd.run(MigrateCmd.java:69)
        at com.google.copybara.Main.runInternal(Main.java:241)
        at com.google.copybara.Main.run(Main.java:123)
        at com.google.copybara.Main.main(Main.java:102)
ERROR: Unexpected error (please file a bug against copybara): No value present (java.util.NoSuchElementException: No value present)
```

I think the right thing to do here is convert the empty `Optional` to
`null`?  In which case I a legitimate error message instead of a crash:

```
ERROR: Cannot find matching parent commit in the destination. Use '--change-request-parent' flag to force a parent commit to use as baseline in the destination.
```

Definitely not 100% sure this fix is correct though, this is as much a
bug report as it is a proposed fix.

Topic: copybara-null-baseline